### PR TITLE
Add teacher login and enforce admin-only enrollment actions

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,14 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import json
+import secrets
 from pathlib import Path
+from pydantic import BaseModel
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +21,27 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+
+def load_teacher_credentials() -> dict:
+    """Load teacher credentials from a JSON file on startup."""
+    teacher_file = current_dir / "teachers.json"
+    if not teacher_file.exists():
+        raise RuntimeError("Missing teachers.json file")
+
+    with open(teacher_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    return data.get("teachers", {})
+
+
+TEACHERS = load_teacher_credentials()
+teacher_sessions = {}
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
 
 # In-memory activity database
 activities = {
@@ -88,9 +112,54 @@ def get_activities():
     return activities
 
 
+def require_teacher(request: Request) -> str:
+    """Allow mutating activity state only for authenticated teachers."""
+    token = request.headers.get("X-Teacher-Token", "")
+    username = teacher_sessions.get(token)
+    if not username:
+        raise HTTPException(status_code=401, detail="Teacher authentication required")
+    return username
+
+
+@app.post("/auth/login")
+def teacher_login(login_data: LoginRequest):
+    expected_password = TEACHERS.get(login_data.username)
+    if not expected_password or expected_password != login_data.password:
+        raise HTTPException(status_code=401, detail="Invalid teacher credentials")
+
+    token = secrets.token_urlsafe(24)
+    teacher_sessions[token] = login_data.username
+    return {
+        "message": f"Logged in as {login_data.username}",
+        "token": token,
+        "username": login_data.username
+    }
+
+
+@app.post("/auth/logout")
+def teacher_logout(request: Request):
+    token = request.headers.get("X-Teacher-Token", "")
+    teacher_sessions.pop(token, None)
+    return {"message": "Logged out"}
+
+
+@app.get("/auth/status")
+def auth_status(request: Request):
+    token = request.headers.get("X-Teacher-Token", "")
+    username = teacher_sessions.get(token)
+    if not username:
+        return {"authenticated": False}
+    return {
+        "authenticated": True,
+        "username": username
+    }
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, request: Request):
     """Sign up a student for an activity"""
+    require_teacher(request)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +180,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, request: Request):
     """Unregister a student from an activity"""
+    require_teacher(request)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,8 +1,94 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const AUTH_TOKEN_KEY = "teacherAuthToken";
+
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const userMenuBtn = document.getElementById("user-menu-btn");
+  const userMenu = document.getElementById("user-menu");
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loginModal = document.getElementById("login-modal");
+  const cancelLoginBtn = document.getElementById("cancel-login-btn");
+  const loginForm = document.getElementById("login-form");
+  const authStatusText = document.getElementById("auth-status-text");
+  const teacherOnlyNote = document.getElementById("teacher-only-note");
+
+  let teacherToken = localStorage.getItem(AUTH_TOKEN_KEY) || "";
+  let teacherName = "";
+  let isTeacherAuthenticated = false;
+
+  function setMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function getAuthHeaders() {
+    if (!teacherToken) {
+      return {};
+    }
+    return { "X-Teacher-Token": teacherToken };
+  }
+
+  function clearAuthState() {
+    teacherToken = "";
+    teacherName = "";
+    isTeacherAuthenticated = false;
+    localStorage.removeItem(AUTH_TOKEN_KEY);
+  }
+
+  function updateAuthUI() {
+    if (isTeacherAuthenticated) {
+      authStatusText.textContent = `Logged in: ${teacherName}`;
+      loginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+      teacherOnlyNote.classList.add("hidden");
+    } else {
+      authStatusText.textContent = "Student view";
+      loginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      teacherOnlyNote.classList.remove("hidden");
+    }
+
+    signupForm
+      .querySelectorAll("input, select, button")
+      .forEach((el) => {
+        el.disabled = !isTeacherAuthenticated;
+      });
+  }
+
+  async function checkAuthStatus() {
+    if (!teacherToken) {
+      clearAuthState();
+      updateAuthUI();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/status", {
+        headers: getAuthHeaders(),
+      });
+      const result = await response.json();
+
+      if (response.ok && result.authenticated) {
+        isTeacherAuthenticated = true;
+        teacherName = result.username;
+      } else {
+        clearAuthState();
+      }
+    } catch (error) {
+      clearAuthState();
+      console.error("Error checking auth status:", error);
+    }
+
+    updateAuthUI();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +98,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +118,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isTeacherAuthenticated
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -57,9 +149,11 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      if (isTeacherAuthenticated) {
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -80,32 +174,27 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: getAuthHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        setMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        if (response.status === 401) {
+          clearAuthState();
+          updateAuthUI();
+          fetchActivities();
+        }
+        setMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      setMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -124,37 +213,106 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: getAuthHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        setMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        if (response.status === 401) {
+          clearAuthState();
+          updateAuthUI();
+          fetchActivities();
+        }
+        setMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      setMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userMenuBtn.addEventListener("click", (event) => {
+    event.stopPropagation();
+    userMenu.classList.toggle("hidden");
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!userMenu.contains(event.target) && event.target !== userMenuBtn) {
+      userMenu.classList.add("hidden");
+    }
+  });
+
+  loginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    userMenu.classList.add("hidden");
+  });
+
+  cancelLoginBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("teacher-username").value.trim();
+    const password = document.getElementById("teacher-password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        teacherToken = result.token;
+        teacherName = result.username;
+        isTeacherAuthenticated = true;
+        localStorage.setItem(AUTH_TOKEN_KEY, teacherToken);
+        updateAuthUI();
+        loginModal.classList.add("hidden");
+        loginForm.reset();
+        setMessage(result.message, "success");
+        fetchActivities();
+      } else {
+        setMessage(result.detail || "Login failed", "error");
+      }
+    } catch (error) {
+      setMessage("Login failed. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: getAuthHeaders(),
+      });
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    clearAuthState();
+    updateAuthUI();
+    userMenu.classList.add("hidden");
+    fetchActivities();
+    setMessage("Logged out", "info");
+  });
+
   // Initialize app
-  fetchActivities();
+  checkAuthStatus().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -7,6 +7,15 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <div id="user-controls" class="user-controls">
+      <button id="user-menu-btn" class="icon-btn" aria-label="User menu">👤</button>
+      <div id="user-menu" class="user-menu hidden">
+        <p id="auth-status-text">Student view</p>
+        <button id="login-btn" type="button">Teacher Login</button>
+        <button id="logout-btn" type="button" class="hidden">Logout</button>
+      </div>
+    </div>
+
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
@@ -23,6 +32,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="teacher-only-note" class="info-banner">
+          Teacher login required to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -40,6 +52,26 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-modal-title">
+      <div class="modal-content">
+        <h3 id="login-modal-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required placeholder="mr_smith" />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required placeholder="••••••••" />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button id="cancel-login-btn" type="button" class="secondary-btn">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <footer>
       <p>&copy; 2026 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -15,6 +15,41 @@ body {
   background-color: #f5f5f5;
 }
 
+.user-controls {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1000;
+}
+
+.icon-btn {
+  border-radius: 50%;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  font-size: 20px;
+}
+
+.user-menu {
+  margin-top: 8px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+  padding: 12px;
+  min-width: 180px;
+}
+
+.user-menu p {
+  margin-bottom: 8px;
+  font-size: 14px;
+}
+
+.user-menu button {
+  width: 100%;
+  margin-top: 8px;
+}
+
 header {
   text-align: center;
   padding: 20px 0;
@@ -55,6 +90,15 @@ section h3 {
   padding-bottom: 10px;
   border-bottom: 1px solid #ddd;
   color: #1a237e;
+}
+
+.info-banner {
+  background-color: #e8f4fd;
+  color: #0c5460;
+  border: 1px solid #bee5eb;
+  border-radius: 4px;
+  padding: 8px;
+  margin-bottom: 12px;
 }
 
 .activity-card {
@@ -164,6 +208,19 @@ button:hover {
   background-color: #3949ab;
 }
 
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.secondary-btn {
+  background-color: #6c757d;
+}
+
+.secondary-btn:hover {
+  background-color: #565e64;
+}
+
 .message {
   margin-top: 20px;
   padding: 10px;
@@ -190,6 +247,37 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  width: min(420px, 90vw);
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.modal-actions button {
+  flex: 1;
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": {
+    "mr_smith": "teach123",
+    "ms_johnson": "classroom456"
+  }
+}


### PR DESCRIPTION
## Summary
Implements issue #5 (Admin Mode) by adding teacher authentication and restricting enrollment mutations to authenticated teachers.

## Changes
- Added backend auth endpoints: `/auth/login`, `/auth/logout`, `/auth/status`
- Added teacher credential storage in `src/teachers.json`
- Enforced teacher token checks for:
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Updated frontend with:
  - top-right user icon/menu
  - teacher login modal
  - login/logout state handling
  - teacher-only signup/unregister controls

## Notes
- Student users can still view participants
- Registration/unregistration now require teacher login

Closes #5